### PR TITLE
Adapt to mc#1300

### DIFF
--- a/theories/extra.v
+++ b/theories/extra.v
@@ -326,6 +326,8 @@ End Relto.
 
 End extra_path.
 
+Arguments eq_symconnect [V r1 r2] _ x y.
+
 Section extra_set.
 Variable (V : finType).
 


### PR DESCRIPTION
https://github.com/math-comp/math-comp/pull/1300 generalizes `eqrel` to dependent functions, so in `(f =2 g) x y`, `x` is now implicit.